### PR TITLE
Version of az cli should be 2.48.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Verify your prerequisites, which depend on whether you\'re using Azure CLI for c
 **Azure CLI**
 -  In a terminal or command window, run func --version to check that the Azure Functions Core Tools are version 4.x.
 -  Run dotnet --list-sdks to check that the required versions are installed.
--  Run az --version to check that the Azure CLI version is 2.4 or later
+-  Run az --version to check that the Azure CLI version is 2.48 or later
 -  Run az login to sign in to Azure and verify an active subscription.
 -  [Docker](https://docs.docker.com/install/) is installed, have a [Docker ID](https://hub.docker.com/signup) and Docker is started
 


### PR DESCRIPTION
In the README section related to prerequisite checks the suggested version of the az cli is 
2.4.x or later.

I tried to follow the tutorial by using 2.41.0 and the parameters **environment** and **image** are not available yet.

![image](https://github.com/Azure/azure-functions-on-container-apps/assets/106186354/1eca447d-7a4c-4168-abc8-840687ddbf51)

Then I upgraded to 2.48.0  and expected parameters are already there.

![image](https://github.com/Azure/azure-functions-on-container-apps/assets/106186354/653d16c7-2a5f-4f5a-bc71-e5d594ae7b4f)

First terminal is CMD and second one is Bash just because I didn't take a screen of the previous version of az cli in Bash when I found the issue.

So I just updated documentation to target a more accurate version of the CLI.